### PR TITLE
Implement slide-in drawer navigation

### DIFF
--- a/style.css
+++ b/style.css
@@ -27,9 +27,6 @@ body{
 .nav{ display:flex; align-items:center; justify-content:space-between; }
 .title{ display:flex; align-items:center; gap:10px; }
 .title .logo{ width:28px; height:28px; background:var(--brand); border-radius:8px; display:grid; place-items:center; color:#fff; font-weight:700; }
-.tabs{ display:flex; gap:6px; flex-wrap:wrap; }
-.tab{ padding:8px 12px; border:1px solid var(--border); background:#fff; border-radius:10px; cursor:pointer; }
-.tab.active{ background:var(--brand); color:#fff; border-color:transparent; }
 
 .grid{ display:grid; gap:16px; }
 .grid-1{ grid-template-columns: 1fr; }
@@ -158,3 +155,40 @@ label{ font-size:14px; color:var(--muted); }
 .chat-panel .hd{ padding:10px 12px; border-bottom:1px solid var(--border); font-weight:700; }
 .chat-panel .bd{ padding:10px 12px; height: calc(100% - 100px); overflow:auto; }
 .chat-panel .ft{ padding:10px 12px; border-top:1px solid var(--border); display:flex; gap:8px; }
+
+  /* --- Slide-in Drawer Menü --- */
+  .drawer-backdrop{
+    position: fixed; inset: 0;
+    background: rgba(15,23,42,0.45);
+    z-index: 100; /* über Chat etc. */
+    display: block;
+  }
+
+  .drawer{
+    position: fixed; top: 0; right: 0; height: 100%;
+    width: clamp(300px, 33vw, 420px);
+    background: #fff;
+    border-left: 1px solid var(--border);
+    box-shadow: var(--shadow);
+    transform: translateX(100%);
+    transition: transform 240ms ease;
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+  }
+  .drawer.open{ transform: translateX(0); }
+
+  .drawer-hd{
+    padding: 12px 14px; border-bottom: 1px solid var(--border);
+    display:flex; align-items:center; justify-content:space-between; gap:10px;
+  }
+  .drawer-bd{
+    padding: 12px; display:flex; flex-direction:column; gap:8px; overflow:auto;
+  }
+  .drawer-bd .item{ text-align:left; }
+  .drawer-ft{
+    padding: 10px 12px; border-top: 1px solid var(--border); text-align:center;
+  }
+
+  /* optional: Scroll-Sperre wenn offen */
+  body:has(.drawer-backdrop){ overflow:hidden; }
+


### PR DESCRIPTION
## Summary
- Replace dropdown menu with a slide-in drawer on the right
- Add DrawerMenu component and mount/unmount logic in render()
- Style drawer backdrop and panel for smooth slide-in interaction

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_6899db8f9e2083268e43ed9315c203e3